### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 ## Overview
 
-This repository contains a driver that uses the [MolSSI Driver Interface](https://github.com/MolSSI/MDI_Library) to perform electric field analysis of [Tinker](https://dasher.wustl.edu/tinker/) trajectories.
+This repository contains a driver that uses the [MolSSI Driver Interface](https://github.com/MolSSI/MDI_Library) to perform electric field analysis of [Tinker](https://dasher.wustl.edu/tinker/) trajectories which use the AMOEBA forcefield. This currently works as a post-processing tool, meaning that you run simulations as normal using Tinker, then analyze the trajectories using
+MDI-enabled Tinker and this driver.
+
+Using this tool, you can calculate the electric field along a bond or between atoms due to other atoms, molecules, or residues in the system.
 
 ## Requirements:
 
-This repository uses the NumPy [NumPy](https://numpy.org/) and [pandas](https://pandas.pydata.org/) Python packages.
+This analysis uses the NumPy [NumPy](https://numpy.org/) and [pandas](https://pandas.pydata.org/) Python packages.
 We recommend installing these packages via Conda:
 
     conda install -c conda-forge numpy pandas
@@ -15,7 +18,48 @@ The repository includes a copy of the [MDI Library](https://github.com/MolSSI/MD
 
 ## Installation
 
-First clone the repository:
+### Compiling MDI-enabled Tinker
+
+Running calculations with this driver will require an [MDI-enabled fork](https://github.com/taylor-a-barnes/Tinker) of Tinker.
+This can be acquired using:
+
+    git clone --branch mdi-ef https://github.com/taylor-a-barnes/Tinker.git
+
+The above clone should be compiled before running calculations with the driver. First, navigate into the cloned repository. It should be compiled from the `mdi-ef` branch:
+
+    cd Tinker
+    git checkout mdi-ef
+
+The build scripts are in the `dev` folder. If it is the first time you are compiling, you should run `full_build.sh`:
+
+    cd dev
+    ./full_build.sh
+
+Your compiled files are now in `../build`. Only the `dynamic.x` Tinker executable is required by this driver.
+
+You will need the location of `dynamic.x` for subsequent installation steps. This file is in `../build/tinker/source/dynamic.x`. To find the full location:
+
+    cd ../
+    cd build
+    cd source
+
+Verify that you have a `dynamic.x` file:
+
+    ls dynamic.x
+
+This should list the file name. Next, note the location of this file.
+
+    pwd
+
+Note the output of this command for the following steps.
+
+### Compiling Electric Field Analysis Driver
+
+Once you have downloaded and compiled MD, you will need to download and compiile the code to do electric field analysis (the code in this repository). Before cloning the repository, make sure you are no longer in the Tinker repo you just built. If you followed along with the previous steps:
+
+    cd ../../../../
+
+Clone this repository:
 
     git clone https://github.com/taylor-a-barnes/MDI_EF_Analysis.git
 
@@ -25,27 +69,26 @@ Then build it using CMake:
     cmake .
     make
 
-Running calculations with this driver will require an [MDI-enabled fork](https://github.com/taylor-a-barnes/Tinker) of Tinker.
-This can be acquired using:
+This will create the MDI driver for electric field calculations in the `build`directory.
 
-    git clone --branch mdi-ef https://github.com/taylor-a-barnes/Tinker.git
+#### Configuration
 
-The above clone should be compiled before running calculations with the driver.
-Only the `dynamic.x` Tinker executable is required by this driver.
-
-## Testing
-
-To test that the build is working, edit the file `MDI_EF_Analysis/test/locations/MDI_EF_Analysis` to provide the **full path** to the `MDI_EF_Analysis.py` Python script.
-If you followed the installation instructions above, this file will be in `[...]/MDI_EF_Analysis/MDI_EF_Analysis/MDI_EF_Analysis.py`
+You will next need to tell the driver the location of the files you just compiled. This is indicated in a text file in the repository. Edit the file `MDI_EF_Analysis/test/locations/MDI_EF_Analysis` to provide the **full path** to the `MDI_EF_Analysis.py` Python script.
+If you followed the installation instructions above, this file will be in `[...]/MDI_EF_Analysis/MDI_EF_Analysis/MDI_EF_Analysis.py`, where `[...]` should be the path appropriate for your system.
 
 Similarly, edit the file `MDI_EF_Analysis/test/locations/Tinker` to provide the **full path** to the `dynamic.x` executable you compiled from the Tinker distribution.
 
-You can now run a quick test of the driver by changing directory to the `MDI_EF_Analysis/test/bench5` directory and running the `tcp.sh` script.
-This script will run a short Tinker dynamics simulation that includes periodic boundary conditions:
+## Testing
+
+You can now run a quick test of the driver by changing directory to the `MDI_EF_Analysis/test/bench5` directory and running the `tcp.sh` script:
+
+    ./tcp.sh
+
+This script will run a short Tinker dynamics simulation that includes periodic boundary conditions. This command is on line 20 of the provided file. This is a standard Tinker call, as you would normally run a simulation. If you are performing post processing on a simulation, you will not use this line.
 
     ${TINKER_LOC} bench5 -k bench5.key 10 1.0 0.001999 2 300.00 > Dynamics.log
 
-It then launches an instance of Tinker as an MDI engine, which will request a connection to the driver and then listen for commands from the driver.
+It then launches an instance of Tinker as an MDI engine, which will request a connection to the driver and then listen for commands from the driver. This line is similar to the above line, except that it uses a modified Tinker input file (more on this below), and adds an additional command line argument which passes information to MDI (`-mdi "role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost"`)
 
     ${TINKER_LOC} bench5 -k no_ewald.key -mdi "-role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost" 10 1.0 0.001999 2 300.00 > no_ewald.log &
 
@@ -59,18 +102,19 @@ The driver's output should match the reference output in the `ref` file.
 
 In general, running a calculation with the driver requires the following steps:
 
-1. Run a dynamics simulation with Tinker.
+1. **Run a dynamics simulation with Tinker.**  
 This simulation should be run with periodic boundary conditions (if desired), and should print snapshots of its results to a single file (i.e., `coordinates.arc`).
 If each snapshot was instead written to a different file (i.e., `coordinates.001`, `coordinates.002`, etc.) then you may concatenate them into a single file.
 
-2. Create a new Tinker keyfile.
-This keyfile should be identical to the one used in Step 1, except that it **must not** include periodic boundary conditions and **must not** use an Ewald summation.
+2. **Create a new Tinker keyfile.**   
+This keyfile should be identical to the one used in Step 1, except that it **must not** include periodic boundary conditions and **must not** use an Ewald summation. This means that in the `.key` file for running the driver, you should not have an `a-axis` keyword, or keywords related to Ewald.
 
-3. Launch one (or more; see the `-nengines` option below) instance(s) of Tinker as an MDI engine, using the keyfile created in Step 2.
-This is done simply by launching the `dynamic.x` executable with the `-mdi` command-line option.
-The argument to this command-line option details how Tinker should connect to the driver; its possible arguments are described in the [MDI documentation](https://molssi.github.io/MDI_Library/html/library_page.html#library_launching_sec).
-When in doubt, we recommend doing `-mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost"`
-When run as an engine, Tinker should be launched in the background; this is done by adding an ampersand (`&`) at the end of the launch line.
+3. **Launch one (or more; see the `-nengines` option below) instance(s) of Tinker as an MDI engine, using the keyfile created in Step 2.**  
+This is done in the same way you launch a normal Tinker simulation (by launching the `dynamic.x` executable) except that the `-mdi` command-line option is added. However, it is **very important** that the reference coordinates you use do not have perioidic boundary information. So, if when you originally ran the simulation you started it with a snapshot from a previous simulation run, make sure to create a new snapshot to launch the simulation from which does not include box information on line 2.
+
+  The argument to the `-mdi` command-line option details how Tinker should connect to the driver; its possible arguments are described in the [MDI documentation](https://molssi.github.io/MDI_Library/html/library_page.html#library_launching_sec).
+  When in doubt, we recommend doing `-mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost"`
+  When run as an engine, Tinker should be launched in the background; this is done by adding an ampersand (`&`) at the end of the launch line.
 
 4. Launch the driver.
 The driver accepts a variety of command-line options, which are described in detail below.
@@ -78,8 +122,8 @@ One possible launch command would be:
 
     `python ${DRIVER_LOC} -probes "1 2 10" -snap coordinates.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" --byres ke15.pdb --equil 51 -nengines 15 &`
 
-   where `DRIVER_LOC` is the path to MDI_EF_Analysis.py.
-   The output will be written to `proj_totfield.py`.
+where `DRIVER_LOC` is the path to MDI_EF_Analysis.py which you set during the configuration step.
+The output will be written to `proj_totfield.csv`.
 
 It is useful to write a script that performs Steps 3 and 4, especially if the calculations are intended to be run on a shared cluster.
 Such a script might look like:
@@ -87,36 +131,68 @@ Such a script might look like:
     # location of required codes
     DRIVER_LOC=$(cat ../locations/MDI_EF_Analysis)
     TINKER_LOC=$(cat ../locations/Tinker)
-    
+
     # number of instances of Tinker to run as an engine
     nengines=18
 
     # set the number of threads used by each code
     export OMP_NUM_THREADS=1
-    
+
     # launch Tinker as an engine
     for i in $( eval echo {1..$nengines} )
     do
     ${TINKER_LOC} coordinates.in -k no_ewald.key -mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost" 10 1.0 1.0 2 300 > no_ewald${i}.log &
     done
-    
+
     # launch the driver
     python ${DRIVER_LOC} -probes "32 33 59 60" -snap coordinates.arc -mdi "-role DRIVER -name driver -method TCP -port 8021" --byres ke15.pdb --equil 51 -nengines ${nengines} &
-    
+
     wait
 
 ## Command-Line Options
 
-This driver accepts the following command-line options:
+You can see command line arguments for this driver using the following command from the top level of this repositry:
 
-  * `-mdi` <br/>
-    **required:** always <br/>
-    **argument:** (string) containing MDI options, as described in the [MDI documentation](https://molssi.github.io/MDI_Library/html/library_page.html#library_launching_sec)
-  * `-nengines` <br/>
-    This option allows the driver to farm tasks out to multiple Tinker engines simultaneously, enabling parallelization of the electric field analysis computation.
-    The argument to this option **must** be equal to the number of Tinker engines that are launched in Step 3 of the usage instructions above.
-    <br/>
-    **required:** only when running with multiple engines <br/>
-    **argument:** (integer) number of engines to use <br/>
-    **default:** 1
+    python MDI_EF_Analysis/MDI_EF_Analysis.py --help
 
+Here is the help information for the command line arguments:
+
+    usage: MDI_EF_Analysis.py [-h] -mdi MDI -snap SNAP -probes PROBES
+                              [-nengines NENGINES] [--equil EQUIL]
+                              [--stride STRIDE] [--byres BYRES] [--bymol]
+
+    required arguments:
+      -mdi MDI            flags for mdi (default: None)
+      -snap SNAP          The file name of the trajectory to analyze. (default:
+                          None)
+      -probes PROBES      Atom indices which are probes for the electric field
+                          calculations. For example, if you would like to
+                          calculate the electric field along the bond between
+                          atoms 1 and 2, you would use `-probes "1 2"`. (default:
+                          None)
+
+    optional arguments:
+      -h, --help          show this help message and exit
+      -nengines NENGINES  This option allows the driver to farm tasks out to
+                          multiple Tinker engines simultaneously, enabling
+                          parallelization of the electric field analysis
+                          computation. The argument to this option **must** be
+                          equal to the number of Tinker engines that are launched
+                          along with the driver. (default: 1)
+      --equil EQUIL       The number of frames to skip performing analysis on at
+                          the beginning of the trajectory file (given by the -snap
+                          argument) For example, using --equil 50 will result in
+                          the first 50 frames of the trajectory being skipped.
+                          (default: 0)
+      --stride STRIDE     The number of frames to skip between analysis
+                          calculations. For example, using --stride 2 would result
+                          in analysis of every other frame in the trajectory.
+                          (default: 1)
+      --byres BYRES       Flag which indicates electric field at the probe atoms
+                          should be calculated with electric field contributions
+                          given per residue. If --byres is indicated, the argument
+                          should be followed by the filename for a pdb file which
+                          gives residues. (default: None)
+      --bymol             Flag which indicates electric field at the probe atoms
+                          should be calculated with electric field contributions
+                          given per molecule. (default: False)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The above clone should be compiled before running calculations with the driver. 
     cd Tinker
     git checkout mdi-ef
 
-The build scripts are in the `dev` folder. If it is the first time you are compiling, you should run `full_build.sh`:
+For convenience, we have provided build scripts in the dev folder. You can either build Tinker in the normal manner, or you can do:
 
     cd dev
     ./full_build.sh
@@ -55,7 +55,7 @@ Note the output of this command for the following steps.
 
 ### Compiling Electric Field Analysis Driver
 
-Once you have downloaded and compiled MD, you will need to download and compiile the code to do electric field analysis (the code in this repository). Before cloning the repository, make sure you are no longer in the Tinker repo you just built. If you followed along with the previous steps:
+Once you have downloaded and compiled MDI, you will need to download and compile the code to do electric field analysis. Before cloning the repository, make sure you are no longer in the Tinker repo you just built. If you followed along with the previous steps:
 
     cd ../../../../
 
@@ -88,11 +88,11 @@ This script will run a short Tinker dynamics simulation that includes periodic b
 
     ${TINKER_LOC} bench5 -k bench5.key 10 1.0 0.001999 2 300.00 > Dynamics.log
 
-It then launches an instance of Tinker as an MDI engine, which will request a connection to the driver and then listen for commands from the driver. This line is similar to the above line, except that it uses a modified Tinker input file (more on this below), and adds an additional command line argument which passes information to MDI (`-mdi "role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost"`)
+The script then launches an instance of Tinker as an MDI engine, which will request a connection to the driver and then listen for commands from the driver. This command is similar to running a simulation with Tinker, except that it uses a modified Tinker input file (more on this below), and adds an additional command line argument which passes information to MDI (`-mdi "role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost"`):
 
     ${TINKER_LOC} bench5 -k no_ewald.key -mdi "-role ENGINE -name NO_EWALD -method TCP -port 8022 -hostname localhost" 10 1.0 0.001999 2 300.00 > no_ewald.log &
 
-It will then launch an instance of the driver in the background, which will listen for connections from an MDI engine:
+The script will then launch an instance of the driver in the background, which will listen for connections from an MDI engine:
 
     python ${DRIVER_LOC} -probes "1 40" -snap bench5.arc -mdi "-role DRIVER -name driver -method TCP -port 8022" --bymol &
 
@@ -110,7 +110,7 @@ If each snapshot was instead written to a different file (i.e., `coordinates.001
 This keyfile should be identical to the one used in Step 1, except that it **must not** include periodic boundary conditions and **must not** use an Ewald summation. This means that in the `.key` file for running the driver, you should not have an `a-axis` keyword, or keywords related to Ewald.
 
 3. **Launch one (or more; see the `-nengines` option below) instance(s) of Tinker as an MDI engine, using the keyfile created in Step 2.**  
-This is done in the same way you launch a normal Tinker simulation (by launching the `dynamic.x` executable) except that the `-mdi` command-line option is added. However, it is **very important** that the reference coordinates you use do not have perioidic boundary information. So, if when you originally ran the simulation you started it with a snapshot from a previous simulation run, make sure to create a new snapshot to launch the simulation from which does not include box information on line 2.
+This is done in the same way you launch a normal Tinker simulation (by launching the `dynamic.x` executable) except that the `-mdi` command-line option is added. However, it is **very important** that the reference coordinates you use do not have periodic boundary information. So, if when you originally ran the simulation you started it with a snapshot from a previous simulation run, make sure to create a new snapshot to launch the simulation from which does not include box information on line 2.
 
   The argument to the `-mdi` command-line option details how Tinker should connect to the driver; its possible arguments are described in the [MDI documentation](https://molssi.github.io/MDI_Library/html/library_page.html#library_launching_sec).
   When in doubt, we recommend doing `-mdi "-role ENGINE -name NO_EWALD -method TCP -port 8021 -hostname localhost"`


### PR DESCRIPTION
This PR adds more information to the driver using the help feature in argparse. The `help` argument has been expanded. The user can see possible arguments and usage for the `MDI_EF_Analysis.py` driver using the command

```
python MDI_EF_Analysis.py --help
```

It seems more effective to do this documentation within the code than to have a thorough description of the command line arguments in the README of the repository.

The README file is also updated to include information on compiling MDI-enabled Tinker, and the output from the `--help` argument described above.